### PR TITLE
Fix Python 3, also add test for count across multiple backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/django_email_multibackend/backends.py
+++ b/django_email_multibackend/backends.py
@@ -1,5 +1,4 @@
 from random import random
-from bisect import bisect
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail import get_connection
@@ -64,7 +63,7 @@ def load_class(path):
     try:
         mod_name, klass_name = path.rsplit('.', 1)
         mod = import_module(mod_name)
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured(('Error importing email backend module %s: "%s"'
                                     % (mod_name, e)))
     try:
@@ -90,7 +89,7 @@ class EmailMultiServerBackend(BaseEmailBackend):
         if kwargs or any(not_supported_params):
             raise TypeError('You cant initialise this backend with %r' % not_supported_params)
 
-        for backend_key, backend_settings in backends.iteritems():
+        for backend_key, backend_settings in backends.items():
             backend_settings['fail_silently'] = fail_silently
             self.servers[backend_key] = get_connection(**backend_settings)
 

--- a/django_email_multibackend/tests.py
+++ b/django_email_multibackend/tests.py
@@ -59,7 +59,7 @@ class TestMultiBackendEmail(unittest.TestCase):
         instance = EmailMultiServerBackend()
         backends = dict.fromkeys(['b1', 'b2'])
         weights = instance.backends_weights(None, backends)
-        self.assertListEqual(list(zip(*weights)[0]), backends.keys())
+        self.assertEqual(set([('b1', 1), ('b2', 1)]), set(weights))
 
     def test_weights(self):
         instance = EmailMultiServerBackend()
@@ -125,6 +125,23 @@ class TestMultiBackendEmail(unittest.TestCase):
         instance = EmailMultiServerBackend(backends=test_backends, backend_weights=test_weights)
         messages = [EmailMessage(), EmailMessage()]
         self.assertEquals(0, instance.send_messages(messages))
+
+    def test_multi_backend_sent_count(self):
+        test_backends = {
+            'mailjet': {
+                'backend': 'django_email_multibackend.tests.FakeSendingBackend',
+                },
+            'mailjet2': {
+                'backend': 'django_email_multibackend.tests.FakeSendingBackend',
+                },
+            }
+
+        test_weights = (
+            ('mailjet', 1),('mailjet2', 1),
+        )
+        instance = EmailMultiServerBackend(backends=test_backends, backend_weights=test_weights)
+        messages = [EmailMessage(), EmailMessage(), EmailMessage(), EmailMessage()]
+        self.assertEquals(4, instance.send_messages(messages))
 
 class TestWeightedChoice(unittest.TestCase):
     def test_low_limit(self):

--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,8 @@ setup(
     description=DESCRIPTION,
     classifiers=CLASSIFIERS,
     tests_require=[
-        'django==1.4.5',
+        'django==1.5',
         'pytest',
-        'unittest2',
     ],
     test_suite='runtests.runtests',
 )


### PR DESCRIPTION
I added the Py3 travis links when removing 2.5 but yes, should have checked that it worked :)

The Python 3 issues were:

- Except syntax (no longer supports the comma version)
- iteritems() has been removed (see e.g.http://stackoverflow.com/questions/13998492/iteritems-in-python)
- I had to change the zip method in the test as it is a generator and not subscriptable
