### PR TITLE
never send a non-iterable to send_messages()

### DIFF
--- a/django_email_multibackend/backends.py
+++ b/django_email_multibackend/backends.py
@@ -126,7 +126,7 @@ class EmailMultiServerBackend(BaseEmailBackend):
 
         for email in email_messages:
             backend = self.get_backend(email)
-            count = backend.send_messages(email)
+            count = backend.send_messages([email, ])
             if count:
                 send_count += count
         return send_count


### PR DESCRIPTION
I'm pretty sure that sending a non-iterable to send_messages() is not ok. This patch just converts the one email_message to an iterable again